### PR TITLE
Fix EuroScope-crash when ASR is closed from the menu

### DIFF
--- a/vSMR/SMRRadar.cpp
+++ b/vSMR/SMRRadar.cpp
@@ -122,6 +122,7 @@ CSMRRadar::~CSMRRadar()
 	}
 	// Shutting down GDI+
 	GdiplusShutdown(m_gdiplusToken);
+	delete CurrentConfig;
 }
 
 void CSMRRadar::LoadCustomFont() {
@@ -313,9 +314,7 @@ void CSMRRadar::OnAsrContentToBeSaved()
 		if (appWindowDisplays[i])
 			to_save = "1";
 		SaveDataToAsr(string(prefix + "Display").c_str(), "Display Secondary Radar Window", to_save.c_str());
-	}
-
-	delete CurrentConfig;
+	}	
 }
 
 void CSMRRadar::OnMoveScreenObject(int ObjectType, const char * sObjectId, POINT Pt, RECT Area, bool Released) {


### PR DESCRIPTION
A potensial fix for #42.

It appears that, different from when EuroScope exits, `OnAsrContentToBeSaved` is called _before_ `OnAsrContentToBeClosed` when the ASR is closed from the menu. EuroScope keeps calling `onRefresh`, but since `CurrentConfig` is already deleted, the function crashes when trying to acces it. Deleting `CurrentConfig` in the destructor ensure it's only deleted at the very end of the class' life cycle.