### PR TITLE
CPDLC Auto-Logoff

### DIFF
--- a/vSMR/SMRPlugin.cpp
+++ b/vSMR/SMRPlugin.cpp
@@ -595,14 +595,6 @@ void CSMRPlugin::OnFunctionCall(int FunctionId, const char * sItemString, POINT 
 	}
 }
 
-void CSMRPlugin::OnControllerDisconnect(CController Controller) {
-	Logger::info(string(__FUNCSIG__));
-	if (Controller.GetFullName() == ControllerMyself().GetFullName() && HoppieConnected == true) {
-		HoppieConnected = false;
-		DisplayUserMessage("CPDLC", "Server", "Logged off!", true, true, false, true, false);
-	}
-}
-
 void CSMRPlugin::OnFlightPlanDisconnect(CFlightPlan FlightPlan)
 {
 	Logger::info(string(__FUNCSIG__));

--- a/vSMR/SMRPlugin.cpp
+++ b/vSMR/SMRPlugin.cpp
@@ -630,6 +630,11 @@ void CSMRPlugin::OnTimer(int Counter)
 		FailedToConnectMessage = false;
 	}
 
+	if (HoppieConnected && GetConnectionType() == CONNECTION_TYPE_NO) {
+		DisplayUserMessage("CPDLC", "Server", "Automatically logged off!", true, true, false, true, false);
+		HoppieConnected = false;
+	}
+
 	if (((clock() - timer) / CLOCKS_PER_SEC) > 10 && HoppieConnected) {
 		_beginthread(pollMessages, 0, NULL);
 		timer = clock();

--- a/vSMR/SMRPlugin.hpp
+++ b/vSMR/SMRPlugin.hpp
@@ -40,10 +40,6 @@ public:
 
 	virtual void OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget, int ItemCode, int TagData, char sItemString[16], int * pColorCode, COLORREF * pRGB, double * pFontSize);
 
-	//---OnControllerDisconnect------------------------------------------
-
-	virtual void OnControllerDisconnect(CController Controller);
-
 	//---OnFlightPlanDisconnect------------------------------------------
 
 	virtual void OnFlightPlanDisconnect(CFlightPlan FlightPlan);


### PR DESCRIPTION
The current implementation of CPDLC auto-logoff doesn't seem to work properly. The `OnControllerDisconnect()` event handler is triggered only when other controllers (including ATIS) disconnect.
